### PR TITLE
implemented remove_range()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,4 +202,63 @@ mod test {
             assert!(m.contains(i));
         }
     }
+
+    #[test]
+    fn remove_range() {
+        let mut m = SplaySet::new();
+        let mut v = Vec::new();
+
+        for i in 0..400 {
+            m.insert(i);
+            v.push(i);
+        }
+
+        let mut output = vec![];
+
+        let m = &mut m;
+        let output = &mut output;
+
+        check_remove_range(m, 42, 142, output, 42, 142);
+
+        check_remove_range(m, 42, 42, output, 42, 42);
+
+        check_remove_range(m, 142, 142, output, 142, 142);
+
+        check_remove_range(m, 42, 142, output, 142, 142);
+
+        check_remove_range(m, 41, 42, output, 41, 42);
+
+        check_remove_range(m, 40, 142, output, 40, 41);
+
+        check_remove_range2(m, 39, 143, output, vec![39, 142]);
+
+        check_remove_range2(m, 1, 399, output, (1..39).chain(143..399).collect());
+
+        check_remove_range(m, 0, 10, output, 0, 1);
+
+        check_remove_range(m, 0, 399, output, 0, 0);
+
+        check_remove_range(m, 400, 1000, output, 0, 0);
+
+        check_remove_range(m, 399, 400, output, 399, 400);
+
+        assert!(m.is_empty(), "size={}", m.len());
+    }
+
+
+    fn check_remove_range(m: &mut SplaySet<usize>, from: usize, to: usize, output: &mut Vec<usize>, expect_from: usize, expect_to: usize) {
+        output.clear();
+        m.remove_range(&from, &to, output);
+        assert!(output.len() == expect_to-expect_from, "len={}, output={:?}", output.len(), output);
+        output.sort();
+        assert_eq!(output, &mut (expect_from..expect_to).collect::<Vec<_>>(), "len={}, output={:?}", output.len(), output);
+    }
+
+    fn check_remove_range2(m: &mut SplaySet<usize>, from: usize, to: usize, output: &mut Vec<usize>, mut expect_items: Vec<usize>) {
+        output.clear();
+        m.remove_range(&from, &to, output);
+        assert!(output.len() == expect_items.len(), "len={}, output={:?}", output.len(), output);
+        output.sort();
+        assert_eq!(output, &mut expect_items, "len={}, output={:?}", output.len(), output);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ mod node;
 #[cfg(test)]
 mod test {
     use super::{SplayMap, SplaySet};
+    use std::ops::Range;
 
     // Lots of these are shamelessly stolen from the TreeMap tests, it'd be
     // awesome if they could share them...
@@ -218,45 +219,45 @@ mod test {
         let m = &mut m;
         let output = &mut output;
 
-        check_remove_range(m, 42, 142, output, 42, 142);
+        check_remove_range(m, 42..142, output, 42, 142);
 
-        check_remove_range(m, 42, 42, output, 42, 42);
+        check_remove_range(m, 42..42, output, 42, 42);
 
-        check_remove_range(m, 142, 142, output, 142, 142);
+        check_remove_range(m, 142..142, output, 142, 142);
 
-        check_remove_range(m, 42, 142, output, 142, 142);
+        check_remove_range(m, 42..142, output, 142, 142);
 
-        check_remove_range(m, 41, 42, output, 41, 42);
+        check_remove_range(m, 41..42, output, 41, 42);
 
-        check_remove_range(m, 40, 142, output, 40, 41);
+        check_remove_range(m, 40..142, output, 40, 41);
 
-        check_remove_range2(m, 39, 143, output, vec![39, 142]);
+        check_remove_range2(m, 39..143, output, vec![39, 142]);
 
-        check_remove_range2(m, 1, 399, output, (1..39).chain(143..399).collect());
+        check_remove_range2(m, 1..399, output, (1..39).chain(143..399).collect());
 
-        check_remove_range(m, 0, 10, output, 0, 1);
+        check_remove_range(m, 0..10, output, 0, 1);
 
-        check_remove_range(m, 0, 399, output, 0, 0);
+        check_remove_range(m, 0..399, output, 0, 0);
 
-        check_remove_range(m, 400, 1000, output, 0, 0);
+        check_remove_range(m, 400..1000, output, 0, 0);
 
-        check_remove_range(m, 399, 400, output, 399, 400);
+        check_remove_range(m, 399..400, output, 399, 400);
 
         assert!(m.is_empty(), "size={}", m.len());
     }
 
 
-    fn check_remove_range(m: &mut SplaySet<usize>, from: usize, to: usize, output: &mut Vec<usize>, expect_from: usize, expect_to: usize) {
+    fn check_remove_range(m: &mut SplaySet<usize>, range: Range<usize>, output: &mut Vec<usize>, expect_from: usize, expect_to: usize) {
         output.clear();
-        m.remove_range(&from, &to, output);
+        m.remove_range(&range.start .. &range.end, output);
         assert!(output.len() == expect_to-expect_from, "len={}, output={:?}", output.len(), output);
         output.sort();
         assert_eq!(output, &mut (expect_from..expect_to).collect::<Vec<_>>(), "len={}, output={:?}", output.len(), output);
     }
 
-    fn check_remove_range2(m: &mut SplaySet<usize>, from: usize, to: usize, output: &mut Vec<usize>, mut expect_items: Vec<usize>) {
+    fn check_remove_range2(m: &mut SplaySet<usize>, range: Range<usize>, output: &mut Vec<usize>, mut expect_items: Vec<usize>) {
         output.clear();
-        m.remove_range(&from, &to, output);
+        m.remove_range(&range.start .. &range.end, output);
         assert!(output.len() == expect_items.len(), "len={}, output={:?}", output.len(), output);
         output.sort();
         assert_eq!(output, &mut expect_items, "len={}, output={:?}", output.len(), output);

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,5 +1,6 @@
 use std::default::Default;
 use std::iter::{FromIterator, IntoIterator};
+use std::ops::Range;
 
 use map::{self, SplayMap};
 
@@ -37,11 +38,11 @@ impl<T: Ord> SplaySet<T> {
     /// present in the set.
     pub fn remove(&mut self, t: &T) -> bool { self.map.remove(t).is_some() }
 
-    /// Removes an open range of values from the set. All values that have been removed are pushed
+    /// Removes a half-open `range` of values from the set. All values that have been removed are pushed
     /// to the end of `output`.
-    pub fn remove_range(&mut self, from: &T, to: &T, output: &mut Vec<T>) {
+    pub fn remove_range(&mut self, range: Range<&T>, output: &mut Vec<T>) {
         let _output: &mut Vec<(T,())> = unsafe { ::std::mem::transmute(output) };
-        self.map.remove_range(from, to, _output);
+        self.map.remove_range(range, _output);
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -36,6 +36,13 @@ impl<T: Ord> SplaySet<T> {
     /// Remove a value from the set. Return true if the value was
     /// present in the set.
     pub fn remove(&mut self, t: &T) -> bool { self.map.remove(t).is_some() }
+
+    /// Removes an open range of values from the set. All values that have been removed are pushed
+    /// to the end of `output`.
+    pub fn remove_range(&mut self, from: &T, to: &T, output: &mut Vec<T>) {
+        let _output: &mut Vec<(T,())> = unsafe { ::std::mem::transmute(output) };
+        self.map.remove_range(from, to, _output);
+    }
 }
 
 impl<T> Iterator for IntoIter<T> {


### PR DESCRIPTION
Could be made less messy if for given query key x, splay() consistently moved to the root the minimal item y satisfying x<=y (except when there is no such item). But then I guess splay() would become more messy, so not sure it's worth exploring.